### PR TITLE
Fix i2c bitbang code

### DIFF
--- a/i2cbb.c
+++ b/i2cbb.c
@@ -33,7 +33,7 @@ void i2cbb_init(uint8_t pin_number_sda, uint8_t pin_number_scl)
 	sleepTimeNanos = 0;
 	nanoSleepTime.tv_sec = 0;
 	nanoSleepTime.tv_nsec = 0;	
-	delayTicks = 0;
+	delayTicks = 100;       // Delay value empirically chosen to be twice the value that just start to cause I2C NACKs - N3SB 
 	i2c_started = 0;
   // Pull up setzen 50KΩ
   // http://wiringpi.com/reference/core-functions/
@@ -87,7 +87,7 @@ static void i2c_sleep() {
 }
 
 static void i2c_delay() {
-    unsigned int index;
+    volatile unsigned int index;        // keeps compiler from optimizing out an empty for-loop
     for (index = 0; index < delayTicks; index++)
         ;
 }
@@ -144,6 +144,7 @@ static void i2c_write_bit(int bit)
         clear_SDA();
     }
     i2c_delay();
+
     while (read_SCL() == 0) { // Clock stretching
       // You should add timeout to this loop
         i2c_sleep();

--- a/sbitx.c
+++ b/sbitx.c
@@ -417,8 +417,8 @@ double agc2(struct rx *r){
 //		printf("Ramping from %g ", r->agc_gain);
   	for (i = 0; i < MAX_BINS/2; i++){
 	  	__imag__ (r->fft_time[i+(MAX_BINS/2)]) *= r->agc_gain;
-			r->agc_gain += agc_ramp;
 		}
+		r->agc_gain += agc_ramp;		
 //		printf("by %g to %g ", agc_ramp, r->agc_gain);
 	}
 	else 

--- a/sbitx_sound.c
+++ b/sbitx_sound.c
@@ -147,6 +147,7 @@ static int exact_rate;   /* Sample rate returned by */
 static int	sound_thread_continue = 0;
 pthread_t sound_thread, loopback_thread;
 
+#define LOOPBACK_LEVEL_DIVISOR 8				// Constant used to reduce audio level to the loopback channel (FLDIGI)
 static int play_write_error = 0;				// count play channel write errors
 static int loopback_write_error = 0;			// count loopback channel write errors
 // Note: Error messages appear when the sbitx program is started from the command line
@@ -666,8 +667,8 @@ int sound_loop(){
 	int jj = 0;
 	int ii = 0;
 	while (ii < ret_card){
-		line_out[jj++] = output_i[ii] / 16;  // Left Channel. Reduce audio level to FLDIGI a bit
-		line_out[jj++] = output_i[ii] / 16;  // Right Channel. Note: FLDIGI does not use the this channel.
+		line_out[jj++] = output_i[ii] / LOOPBACK_LEVEL_DIVISOR;  // Left Channel. Reduce audio level to FLDIGI a bit
+		line_out[jj++] = output_i[ii] / LOOPBACK_LEVEL_DIVISOR;  // Right Channel. Note: FLDIGI does not use the this channel.
 		// The right channel can be used to output other integer values such as AGC, for capture by an
 		// application such as audacity.
 		ii += 2;	// Skip a pair of samples to account for the 96K sample to 48K sample rate change.


### PR DESCRIPTION
Summary: This change may make a very big improvement in VFO behavior, and band changing.

This change improves the bit-banged I2C code which drives the SI5351 synthesizer IC. The change has two parts:
1) Retry I2C commands that are NACKed by the SI5351,
2) Add small delays to allow setup and hold times for I2C waveforms to stabilize. Code was already in place to support these delays, but the delay value was zero. With no delay, many commands were being NACKed, and since there was no mechanism in place to repeat those commands, the SI5351 did not get properly programmed. This caused the receive frequency to not follow what was being tuned by the VFO knob, I just increased the delay until I saw no NACKs, then doubled the result. A proper approach is to measure the timing of the I2C waveforms with an oscilloscope. I'll do that sometime.

73; Steve, N3SB