### PR TITLE
Change the FT8 decode time to the cycle start, not end

### DIFF
--- a/modem_ft8.c
+++ b/modem_ft8.c
@@ -374,8 +374,14 @@ int sbitx_ft8_decode(float *signal, int num_samples, bool is_ft8)
         .protocol = is_ft8 ? PROTO_FT8 : PROTO_FT4
     };
 
+    // subtract seconds to display the cycle start time, not the decode time
+    int cycle_seconds = 15;
+    if (is_ft8 == false) {
+        cycle_seconds = 7;
+    }
+   
 		//timestamp the packets
-		time_t	rawtime = time_sbitx();
+		time_t	rawtime = time_sbitx() - cycle_seconds;
 		char time_str[20], response[100];
 		struct tm *t = gmtime(&rawtime);
 		sprintf(time_str, "%02d%02d%02d", t->tm_hour, t->tm_min, t->tm_sec);


### PR DESCRIPTION
WSJT-X, JTDX, Smart-SDR (Flex), SDR-Console (Icom) and other FT8 applications all use the cycle start time when printing out lines, rather then the end of the cycle at the decode time.

This fix simply subtracts 15 seconds or 7 seconds for FT8/FT4 respectively so that the display matches what all the other applications do, and what users would expect to see.