### PR TITLE
Improvements around pulseaudio opening PCM capture device

### DIFF
--- a/install.txt
+++ b/install.txt
@@ -42,11 +42,12 @@ precision float library.
 ##Step 5: INSTALLING LOOPBACK
 
 IMPORTANT: pulseaudio maybe taking over ALSA sound system that sbitx runs on 
-edit /etc/pulse/client.conf and add the line
+edit /etc/pulse/client.conf and add the lines
 
 	autospawn = no
+	daemon-binary = /bin/true
 
-to disable it.
+to prevent it.
 
 We need a way to pass audio between the sbitx and other programs running on the RPi like
 WSJT-X, etc.

--- a/sbitx_sound.c
+++ b/sbitx_sound.c
@@ -140,7 +140,6 @@ static snd_pcm_t *loopback_capture_handle=0;   	//handle for the pcm device
 static snd_pcm_stream_t play_stream = SND_PCM_STREAM_PLAYBACK;	//playback stream
 static snd_pcm_stream_t capture_stream = SND_PCM_STREAM_CAPTURE;	//playback stream
 
-static char	*pcm_play_name, *pcm_capture_name;
 static snd_pcm_hw_params_t *hwparams;
 static snd_pcm_sw_params_t *swparams;
 static snd_pcm_hw_params_t *hloop_params;
@@ -363,7 +362,7 @@ int sound_start_capture(char *device){
 	int e = snd_pcm_open(&pcm_capture_handle, device,  	capture_stream, 0);
 	
 	if (e < 0) {
-		fprintf(stderr, "Error opening PCM capture device %s: %s\n", pcm_capture_name, snd_strerror(e));
+		fprintf(stderr, "Error opening PCM capture device %s: %s\n", device, snd_strerror(e));
 		return -1;
 	}
 
@@ -780,18 +779,18 @@ void *sound_thread_function(void *ptr){
 			printf("Retrying the sound system %d\n", i);
 	}
 	if (i == 10){
-	 fprintf(stderr, "*Error opening play device");
+	 fprintf(stderr, "*Error opening play device\n");
 		return NULL;
 	}
 
 	if (sound_start_capture(device)){
-		fprintf(stderr, "*Error opening capture device");
+		fprintf(stderr, "*Error opening capture device\n");
 		return NULL;
 	}
 
 //  printf("opening loopback on plughw:1,0 sound card\n");	
 	if(sound_start_loopback_play("plughw:1,0")){
-		fprintf(stderr, "*Error opening loopback play device");
+		fprintf(stderr, "*Error opening loopback play device\n");
 		return NULL;
 	}
 	sound_thread_continue = 1;
@@ -809,7 +808,7 @@ void *loopback_thread_function(void *ptr){
 //  printf("opening loopback on plughw:1,0 sound card\n");	
 
 	if (sound_start_loopback_capture("plughw:2,1")){
-		fprintf(stderr, "*Error opening loopback capture device");
+		fprintf(stderr, "*Error opening loopback capture device\n");
 		return NULL;
 	}
 	sound_thread_continue = 1;


### PR DESCRIPTION
I accidentally added software that depended on pulseaudio onto my sbitx device so the sbitx program would not run because pulseaudio had the PCM devices opened.  

When debugging this I found that the error message being printed said the capture device being opened was (null) because the fprintf() statement was not using the same variable as the snd_pcm_open() statement, it was using a global variable that was set to NULL and never used it again.  I got rid of this variable and a similar one set up for the play device but totally unused.  

I also found some related fprintf() messages did not end with newline so it was hard to read the output, so I added the newlines.

And I found via googling that the info in the install.txt did not completely deal with the situation.  The improved advise sets the daemon-binary to /bin/true so any component that tries to spawn pulseaudio actually ends up spawning /bin/true which keeps it satisfied without actually starting pulseaudio. 