### PR TITLE
Improve straight key operation

### DIFF
--- a/sbitx_gtk.c
+++ b/sbitx_gtk.c
@@ -3414,7 +3414,7 @@ int key_poll(){
 			key |= CW_DOT;
 	}
 	//straight key
-	else if (digitalRead(PTT) == LOW || digitalRead(DASH) == LOW)
+	else if (digitalRead(DASH) == LOW)
 			key = CW_DOWN;
 
 	//printf("key %d\n", key);

--- a/sbitx_gtk.c
+++ b/sbitx_gtk.c
@@ -3829,9 +3829,9 @@ gboolean ui_tick(gpointer gook){
 	//straight key in CW
 	if (f && (!strcmp(f->value, "2TONE") || !strcmp(f->value, "LSB") || 
 	!strcmp(f->value, "USB"))){
-		if (digitalRead(PTT) == LOW && in_tx == 0)
+		if (digitalRead(DASH) == LOW && in_tx == 0)
 			tx_on(TX_PTT);
-		else if (digitalRead(PTT) == HIGH && in_tx  == TX_PTT)
+		else if (digitalRead(DASH) == HIGH && in_tx  == TX_PTT)
 			tx_off();
 	}
 


### PR DESCRIPTION
I have a straight key wired with a mono plug. When I insert it into sbitx in CW mode, it immediately keys the radio.  This does not happen on any of the other radios I have access to, for instance Flex and Hermes Lite.  It's common to use mono plugs for straight keys, they are cheaper.  The straight key code should just look for when the tip is low, not when ring or sleeve is low, because ring and sleeve are always connected and they will always be low. 