### PR TITLE
Improvements to the update script

### DIFF
--- a/update
+++ b/update
@@ -1,3 +1,7 @@
+#!/bin/sh -e
+# Note: the '-e' flag will make the script stop immediately upon error with 
+# the error reflected in the environment.  This makes it easier for users to
+# see which command caused the error.
 F=$@
 echo ">>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>"
 date


### PR DESCRIPTION
Similar to the build script, adding '-e' to the shell command will make it stop as soon as it encounters an error.  This makes it clearer to the user which command caused the error (git pull vs ./build sbitx).  We have seen one case of the user missing the git pull error recently and this would help avoid that in the future.