### PR TITLE
Increase FFTW library algorithm search rigor;  add support for wisdom files - all to reduce waterfall hallucinations

### DIFF
--- a/sbitx.c
+++ b/sbitx.c
@@ -1,7 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
-#include <fcntl.h> 
+#include <fcntl.h>
 #include <math.h>
 #include <complex.h>
 #include <fftw3.h>
@@ -21,6 +21,8 @@
 #include "i2cbb.h"
 #include "si5351.h"
 #include "ini.h"
+
+#define DEBUG 0
 
 char audio_card[32];
 static int tx_shift = 512;
@@ -50,6 +52,15 @@ fftw_plan plan_spectrum;
 float spectrum_window[MAX_BINS];
 void set_rx1(int frequency);
 void tr_switch(int tx_on);
+
+// Wisdom Defines for the FFTW and FFTWF libraries
+// Options for WISDOM_MODE from least to most rigorous are FFTW_ESTIMATE, FFTW_MEASURE, FFTW_PATIENT, and FFTW_EXHAUSTIVE
+// The FFTW_ESTIMATE mode seems to make completely incorrect Wisdom plan choices sometimes, and is not recommended.
+// Wisdom plans found in an existing Wisdom file will negate the need for time consuming Wisdom plan calculations
+// if the Wisdom plans in the file were generated at the same or more rigorous level.
+#define WISDOM_MODE FFTW_MEASURE
+#define PLANTIME -1		// spend no more than plantime seconds finding the best FFT algorithm. -1 turns the platime cap off.
+char wisdom_file[] = "sbitx_wisdom.wis";
 
 fftw_complex *fft_out;		// holds the incoming samples in freq domain (for rx as well as tx)
 fftw_complex *fft_in;			// holds the incoming samples in time domain (for rx as well as tx) 
@@ -130,12 +141,12 @@ void radio_tune_to(u_int32_t f){
 }
 
 void fft_init(){
-	int mem_needed;
+	// int mem_needed;
 
 	//printf("initializing the fft\n");
 	fflush(stdout);
 
-	mem_needed = sizeof(fftw_complex) * MAX_BINS;
+	// mem_needed = sizeof(fftw_complex) * MAX_BINS;
 
 	fft_m = (fftw_complex*) fftw_malloc(sizeof(fftw_complex) * MAX_BINS/2);
 	fft_in = (fftw_complex*) fftw_malloc(sizeof(fftw_complex) * MAX_BINS);
@@ -147,8 +158,16 @@ void fft_init(){
 	memset(fft_out, 0, sizeof(fftw_complex) * MAX_BINS);
 	memset(fft_m, 0, sizeof(fftw_complex) * MAX_BINS/2);
 
-	plan_fwd = fftw_plan_dft_1d(MAX_BINS, fft_in, fft_out, FFTW_FORWARD, FFTW_ESTIMATE);
-	plan_spectrum = fftw_plan_dft_1d(MAX_BINS, fft_in, fft_spectrum, FFTW_FORWARD, FFTW_ESTIMATE);
+	fftw_set_timelimit(PLANTIME);
+	fftwf_set_timelimit(PLANTIME);
+	int e = fftw_import_wisdom_from_filename(wisdom_file);
+	if (e == 0)
+	{
+		printf("Generating Wisdom File...\n");
+	}
+	plan_fwd = fftw_plan_dft_1d(MAX_BINS, fft_in, fft_out, FFTW_FORWARD, WISDOM_MODE); // Was FFTW_ESTIMATE N3SB
+	plan_spectrum = fftw_plan_dft_1d(MAX_BINS, fft_in, fft_spectrum, FFTW_FORWARD, WISDOM_MODE); // Was FFTW_ESTIMATE N3SB
+	fftw_export_wisdom_to_filename(wisdom_file);
 
 	//zero up the previous 'M' bins
 	for (int i= 0; i < MAX_BINS/2; i++){
@@ -240,18 +259,24 @@ void set_lpf_40mhz(int frequency){
 		lpf = LPF_A; 
 
 	if (lpf == prev_lpf){
-		//puts("LPF not changed");
+#if DEBUG > 0		
+		puts("LPF not changed");
+#endif		
 		return;
 	}
-
-	//printf("##################Setting LPF to %d\n", lpf);
+	
+#if DEBUG > 0
+	printf("##################Setting LPF to %d\n", lpf);
+#endif
 
   digitalWrite(LPF_A, LOW);
   digitalWrite(LPF_B, LOW);
   digitalWrite(LPF_C, LOW);
   digitalWrite(LPF_D, LOW);
 
-  //printf("################ setting %d high\n", lpf);
+#if DEBUG > 0
+  printf("################ setting %d high\n", lpf);
+#endif 
   digitalWrite(lpf, HIGH); 
 	prev_lpf = lpf;
 }
@@ -362,8 +387,15 @@ struct rx *add_tx(int frequency, short mode, int bpf_low, int bpf_high){
 	//create fft complex arrays to convert the frequency back to time
 	r->fft_time = (fftw_complex*) fftw_malloc(sizeof(fftw_complex) * MAX_BINS);
 	r->fft_freq = (fftw_complex*) fftw_malloc(sizeof(fftw_complex) * MAX_BINS);
-	r->plan_rev = fftw_plan_dft_1d(MAX_BINS, r->fft_freq, r->fft_time, FFTW_BACKWARD, FFTW_ESTIMATE);
-
+	
+	int e = fftw_import_wisdom_from_filename(wisdom_file);
+	if (e == 0)
+	{
+		printf("Generating Wisdom File...\n");
+	}	
+	r->plan_rev = fftw_plan_dft_1d(MAX_BINS, r->fft_freq, r->fft_time, FFTW_BACKWARD, WISDOM_MODE); // Was FFTW_ESTIMATE N3SB
+	fftw_export_wisdom_to_filename(wisdom_file);
+	
 	r->output = 0;
 	r->next = NULL;
 	r->mode = mode;
@@ -403,8 +435,15 @@ struct rx *add_rx(int frequency, short mode, int bpf_low, int bpf_high){
 	//create fft complex arrays to convert the frequency back to time
 	r->fft_time = (fftw_complex*) fftw_malloc(sizeof(fftw_complex) * MAX_BINS);
 	r->fft_freq = (fftw_complex*) fftw_malloc(sizeof(fftw_complex) * MAX_BINS);
-	r->plan_rev = fftw_plan_dft_1d(MAX_BINS, r->fft_freq, r->fft_time, FFTW_BACKWARD, FFTW_ESTIMATE);
-
+	
+	int e = fftw_import_wisdom_from_filename(wisdom_file);
+	if (e == 0)
+	{
+		printf("Generating Wisdom File...\n");
+	}	
+	r->plan_rev = fftw_plan_dft_1d(MAX_BINS, r->fft_freq, r->fft_time, FFTW_BACKWARD, WISDOM_MODE);  // Was FFTW_ESTIMATE N3SB
+	fftw_export_wisdom_to_filename(wisdom_file);
+	
 	r->output = 0;
 	r->next = NULL;
 	r->mode = mode;
@@ -510,8 +549,6 @@ void rx_process(int32_t *input_rx,  int32_t *input_mic,
 {
 	int i, j = 0;
 	double i_sample, q_sample;
-
-
 
 	//STEP 1: first add the previous M samples to
 	for (i = 0; i < MAX_BINS/2; i++)
@@ -813,7 +850,6 @@ void sound_process(
 	int32_t *output_speaker, int32_t *output_tx, 
 	int n_samples)
 {
-
 	if (in_tx)
 		tx_process(input_rx, input_mic, output_speaker, output_tx, n_samples);
 	else
@@ -1071,7 +1107,7 @@ void tr_switch_de(int tx_on){
 			if (tr_relay){
   			digitalWrite(LPF_A, LOW);
   			digitalWrite(LPF_B, LOW);
- 	 			digitalWrite(LPF_C, LOW);
+ 	 		digitalWrite(LPF_C, LOW);
   			digitalWrite(LPF_D, LOW);
 			}
 			delay(10);
@@ -1094,7 +1130,7 @@ void tr_switch_v2(int tx_on){
 			//first turn off the LPFs, so PA doesnt connect 
   		digitalWrite(LPF_A, LOW);
   		digitalWrite(LPF_B, LOW);
- 	 		digitalWrite(LPF_C, LOW);
+ 	 	digitalWrite(LPF_C, LOW);
   		digitalWrite(LPF_D, LOW);
 
 			//mute it all and hang on for a millisecond
@@ -1127,7 +1163,7 @@ void tr_switch_v2(int tx_on){
 
   		digitalWrite(LPF_A, LOW);
   		digitalWrite(LPF_B, LOW);
- 	 		digitalWrite(LPF_C, LOW);
+ 	 	digitalWrite(LPF_C, LOW);
   		digitalWrite(LPF_D, LOW);
 			prev_lpf = -1; //force the lpf to be re-energized
 			delay(10);
@@ -1383,5 +1419,3 @@ void sdr_request(char *request, char *response){
   /* else
 		printf("*Error request[%s] not accepted\n", request); */
 }
-
-


### PR DESCRIPTION
Changed fft_filter.c and sbitx.c to increase the level of FFTW library algorithm search rigor, and to add support for Wisdom files.

Occasionally the sbitx program will start up in a strange mode where sensitivity is reduced, images are present in the waterfall. The problem was isolated to the way that the FFTW library would guess at an FFT algorithm. Increasing the level of rigor used by the library to find an algorithm has been demonstrated to eliminate the problem, however the increased level of rigor then increases sbitx program startup time to almost a minute. To solve that issue, support for Wisdom files has been added. If a Wisdom file does not exist then the FFTW library will find a good FFT algorithm, and then save it to the Wisdom file so that there will be no delay when the program is started again.