### PR TITLE
Update sbitx_gtk.c to correct logging issues

### DIFF
--- a/sbitx_gtk.c
+++ b/sbitx_gtk.c
@@ -1338,13 +1338,13 @@ void enter_qso(){
 	const char *rst_received = field_str("RECV");
 
 	// skip empty or half filled log entry
-	if (strlen(callsign) < 3 || strlen(rst_sent) < 2 || strlen(rst_received) < 2){
+	if (strlen(callsign) < 3 || strlen(rst_sent) < 1 || strlen(rst_received) < 1){
 		printf("log entry is empty [%s], [%s], [%s], no log created\n", callsign, rst_sent, rst_received);
 		return;
 	}
  
-	if (logbook_count_dup(field_str("CALL"), 120)){
-		printf("duplicate log entry aborted within 60 seconds\n");
+	if (logbook_count_dup(field_str("CALL"), 60)){
+		printf("Duplicate log entry not accepted for %s within two minutes of last entry of %s.\n", callsign, callsign);
 		return;
 	}	
 	logbook_add(get_field("#contact_callsign")->value, 


### PR DESCRIPTION
Change logbook field validation code to allow single characters. The current FT8 decoder will provide a single digit if the signal strength is between 0 and 9. The current logbook validation will not accept a single digit.

NOTE: The current FT8 code will also send the single digit as a signal report, when the convention appears to be to append the signal report with a sign, either "-" or "+", so the FT8 code should be looked at as well. 