### PR TITLE
web app band selection fix, and 60m added.

### DIFF
--- a/data/default_hw_settings.ini
+++ b/data/default_hw_settings.ini
@@ -6,6 +6,11 @@ f_stop=4000000
 scale=0.00255477
 
 [tx_band]
+f_start=5250000
+f_stop=5450000
+scale=0.002
+
+[tx_band]
 f_start=7000000
 f_stop=7300000
 scale=0.00174494

--- a/data/hw_settings_v3.ini
+++ b/data/hw_settings_v3.ini
@@ -7,6 +7,11 @@ scale=0.005
 clip = 250000000
 
 [tx_band]
+f_start=5250000
+f_stop=5450000
+scale=0.005
+
+[tx_band]
 f_start=7000000
 f_stop=7300000
 scale=0.0045

--- a/sbitx_gtk.c
+++ b/sbitx_gtk.c
@@ -4046,10 +4046,10 @@ gboolean ui_tick(gpointer gook){
 		update_titlebar();
 
 		if (digitalRead(ENC1_SW) == 0){
-			//flip between mode and volume
-			if (f_focus && !strcmp(f_focus->label, "AUDIO"))
-				focus_field(get_field("r1:mode"));
-			else
+			////flip between mode and volume // llh: better to just focus volume
+			//if (f_focus && !strcmp(f_focus->label, "AUDIO"))
+			//	focus_field(get_field("r1:mode"));
+			//else
 				focus_field(get_field("r1:volume"));
 			printf("Focus is on %s\n", f_focus->label);
 		}

--- a/sbitx_gtk.c
+++ b/sbitx_gtk.c
@@ -52,6 +52,7 @@ The initial sync between the gui values, the core radio values, settings, et al 
 #define FT8_CONTINUE_QSO 0
 void ft8_process(char *received, int operation);
 void change_band(char *request);
+void highlight_band_field(int new_band);
 
 /* command  buffer for commands received from the remote */
 struct Queue q_remote_commands;
@@ -174,6 +175,7 @@ struct font_style font_table[] = {
 	{FF_MYCALL, 0.2, 1, 0, "Mono", 11, CAIRO_FONT_WEIGHT_NORMAL, CAIRO_FONT_SLANT_NORMAL},
 	{FF_CALLER, 1, 0.2, 0, "Mono", 11, CAIRO_FONT_WEIGHT_NORMAL, CAIRO_FONT_SLANT_NORMAL},
 	{FF_GRID,   1, 0.8, 0, "Mono", 11, CAIRO_FONT_WEIGHT_NORMAL, CAIRO_FONT_SLANT_NORMAL},
+	{FONT_FIELD_SELECTED, 0.3, 1, 0, "Mono", 15, CAIRO_FONT_WEIGHT_NORMAL, CAIRO_FONT_SLANT_NORMAL},
 };
 
 struct encoder enc_a, enc_b;
@@ -405,17 +407,18 @@ static int tx_mode = MODE_USB;
 
 
 #define BAND80M	0
-#define BAND40M	1
-#define BAND30M 2	
-#define BAND20M 3	
-#define BAND17M 4	
-#define BAND15M 5
-#define BAND12M 6 
-#define BAND10M 7 
+#define BAND60M	1
+#define BAND40M	2
+#define BAND30M 3	
+#define BAND20M 4	
+#define BAND17M 5	
+#define BAND15M 6
+#define BAND12M 7 
+#define BAND10M 8
 
 struct band band_stack[] = {
 	{"80M", 3500000, 4000000, 0, 
-		{3500000,3574000,3600000,3700000},{MODE_CW, MODE_LSB, MODE_CW,MODE_LSB}},
+		{3500000,3574000,3600000,3700000},{MODE_CW, MODE_LSB, MODE_CW, MODE_LSB}},
 	{"60M", 5250000, 5500000, 0, 
 		{5251500, 5354000,5357000,5360000},{MODE_CW, MODE_USB, MODE_USB, MODE_USB}},
 	{"40M", 7000000,7300000, 0,
@@ -491,23 +494,23 @@ int current_layout = LAYOUT_KBD;
 struct field main_controls[] = {
 	/* band stack registers */
 	{"#10m", NULL, 50, 5, 40, 40, "10M", 1, "1", FIELD_BUTTON, FONT_FIELD_VALUE, 
-		"", 0,0,0,COMMON_CONTROL},
+		"", 1,4,1,COMMON_CONTROL},
 	{"#12m", NULL, 90, 5, 40, 40, "12M", 1, "1", FIELD_BUTTON, FONT_FIELD_VALUE, 
-		"", 0,0,0,COMMON_CONTROL},
+		"", 1,4,1,COMMON_CONTROL},
 	{"#15m", NULL, 130, 5, 40, 40, "15M", 1, "1", FIELD_BUTTON, FONT_FIELD_VALUE, 
-		"", 0,0,0,COMMON_CONTROL},
+		"", 1,4,1,COMMON_CONTROL},
 	{"#17m", NULL, 170, 5, 40, 40, "17M", 1, "1", FIELD_BUTTON, FONT_FIELD_VALUE, 
-		"", 0,0,0,COMMON_CONTROL},
+		"", 1,4,1,COMMON_CONTROL},
 	{"#20m", NULL, 210, 5, 40, 40, "20M", 1, "1", FIELD_BUTTON, FONT_FIELD_VALUE, 
-		"", 0,0,0,COMMON_CONTROL},
+		"", 1,4,1,COMMON_CONTROL},
 	{"#30m", NULL, 250, 5, 40, 40, "30M", 1, "1", FIELD_BUTTON, FONT_FIELD_VALUE, 
-		"", 0,0,0,COMMON_CONTROL},
+		"", 1,4,1,COMMON_CONTROL},
 	{"#40m", NULL, 290, 5, 40, 40, "40M", 1, "1", FIELD_BUTTON, FONT_FIELD_VALUE, 
-		"", 0,0,0,COMMON_CONTROL},
+		"", 1,4,1,COMMON_CONTROL},
 	{"#60m", NULL, 330, 5, 40, 40, "60M", 1, "1", FIELD_BUTTON, FONT_FIELD_VALUE, 
-		"", 0,0,0,COMMON_CONTROL},
+		"", 1,4,1,COMMON_CONTROL},
 	{"#80m", NULL, 370, 5, 40, 40, "80M", 1, "1", FIELD_BUTTON, FONT_FIELD_VALUE, 
-		"", 0,0,0,COMMON_CONTROL},
+		"", 1,4,1,COMMON_CONTROL},
 	{ "#record", do_record, 420, 5, 40, 40, "REC", 40, "OFF", FIELD_TOGGLE, FONT_FIELD_VALUE, 
 		"ON/OFF", 0,0, 0,COMMON_CONTROL},
 	{"#set", NULL, 460, 5, 40, 40, "SET", 1, "", FIELD_BUTTON, FONT_FIELD_VALUE,"", 0,0,0,COMMON_CONTROL}, 
@@ -816,9 +819,10 @@ int set_field(const char *id, const char *value){
 		char *p, *prev, *next, b[100];
 		//search the current text in the selection
 		prev = NULL;
-		if (debug)
-			printf("field selection [%s]\n");
+		
 		strcpy(b, f->selection);
+        if (debug)
+			printf("field selection [%s] value=[%s]\n", b, value);
 		p = strtok(b, "/");
 		if (debug)
 			printf("first token [%s]\n", p);
@@ -833,9 +837,9 @@ int set_field(const char *id, const char *value){
 		}	
 		//set to the first option
 		if (p == NULL){
-			if (prev)
-				strcpy(f->value, prev);
-			printf("*Error: setting field[%s] to [%s] not permitted\n", f->cmd, value);
+			//if (prev)
+			//	strcpy(f->value, prev);
+			//printf("*Error: setting field[%s] to [%s] not permitted\n", f->cmd, value);
 			return 1;
 		}
 		else{
@@ -1290,29 +1294,32 @@ void draw_field(GtkWidget *widget, cairo_t *gfx, struct field *f){
 		case FIELD_NUMBER:
 		case FIELD_TOGGLE:
 		case FIELD_BUTTON:
-			label_height = font_table[FONT_FIELD_LABEL].height;
-			width = measure_text(gfx, label, FONT_FIELD_LABEL);
+		{
+		    int font_ix = f->font_index; // FONT_FIELD_LABEL
+			label_height = font_table[font_ix].height;
+			width = measure_text(gfx, label, font_ix);
 			//skip the underscore in the label if it is too wide
 			if (width > f->width && strchr(label, '_')){
 				label = strchr(label, '_') + 1;
-				width = measure_text(gfx, label, FONT_FIELD_LABEL);
+				width = measure_text(gfx, label, font_ix);
 			}
 
 			offset_x = f->x + f->width/2 - width/2;
 			//is it a two line display or a single line?
-			if (f->value_type == FIELD_BUTTON && !f->value[0]){
+			if ((f->value_type == FIELD_BUTTON) && !f->value[0]){
 				label_y = f->y + (f->height - label_height)/2;
-				draw_text(gfx, offset_x,label_y, f->label, FONT_FIELD_LABEL);
+				draw_text(gfx, offset_x,label_y, f->label, font_ix);
 			} 
 			else {
-				value_height = font_table[FONT_FIELD_VALUE].height;
+				value_height = font_table[font_ix].height;
 				label_y = f->y + ((f->height  - label_height  - value_height)/2);
-				draw_text(gfx, offset_x, label_y, label, FONT_FIELD_LABEL);
+				draw_text(gfx, offset_x, label_y, label, font_ix);
 				width = measure_text(gfx, f->value, FONT_FIELD_VALUE);
 				label_y += font_table[FONT_FIELD_LABEL].height;
 				draw_text(gfx, f->x + f->width/2 - width/2, label_y, f->value, 
 					FONT_FIELD_VALUE);
 			}
+		}
       break;
 		case FIELD_STATIC:
 			draw_text(gfx, f->x, f->y, f->label, FONT_FIELD_LABEL);
@@ -1419,6 +1426,7 @@ static void save_user_settings(int forced){
 	fclose(f);
 	last_save_at = now;	// As proposed by Dave N1AI
 	settings_updated = 0;
+	//printf("user_settings saved\n");
 }
 
 
@@ -1469,55 +1477,79 @@ static int user_settings_handler(void* user, const char* section,
 	}
     // if it is an empty section
     else if (strlen(section) == 0){
-      sprintf(cmd, "%s", name);
-			//skip the button actions 
-			struct field *f = get_field(cmd);
-			if (f){
-				if (f->value_type != FIELD_BUTTON)
-      		set_field(cmd, new_value); 
+    	sprintf(cmd, "%s", name);
+		//skip the button actions 
+		struct field *f = get_field(cmd);
+		if (f) {
+			if (f->value_type != FIELD_BUTTON)
+				set_field(cmd, new_value); 
+
+			// Set the selected band stack index (Not elegant but alas ...)
+			char * bands = "#80m#60m#40m#30m#20m#17m#15m#12m#10m";
+			char * ptr = strstr(bands, cmd);
+			if (ptr != NULL) {
+				//printf("Setting band stack index: section=%s name=%s value=%s p=%d\n", section, name, value, ptr-bands);
+				int band = (ptr-bands)/4;
+				int ix = atoi(value)-1;
+				band_stack[band].index = ix;
+				strcpy(f->value, value);
+				settings_updated++;
 			}
+			if (!strcmp(cmd,"#selband")) {
+				int bi = atoi(value);
+				int new_band = bi/10;
+				//int i = bi%10;
+				highlight_band_field(new_band);
+			}	
+		}
+		return 1;
     }
 
-		//band stacks
-		int band = -1;
-		if (!strcmp(section, "80M"))
-			band = 0;
-		else if (!strcmp(section, "40M"))
-			band = 1;
-		else if (!strcmp(section, "30M"))
-			band = 2;
-		else if (!strcmp(section, "20M"))
-			band = 3;
-		else if (!strcmp(section, "17M"))
-			band = 4;
-		else if (!strcmp(section, "15M"))
-			band = 5;
-		else if (!strcmp(section, "12M"))	
-			band = 6;
-		else if (!strcmp(section, "10M"))
-			band = 7;	
+	//band stacks
+	int band = -1;
+	if (!strcmp(section, "80M"))
+		band = BAND80M;
+	else if (!strcmp(section, "60M"))
+		band = BAND60M;
+	else if (!strcmp(section, "40M"))
+		band = BAND40M;
+	else if (!strcmp(section, "30M"))
+		band = BAND30M;
+	else if (!strcmp(section, "20M"))
+		band = BAND20M;
+	else if (!strcmp(section, "17M"))
+		band = BAND17M;
+	else if (!strcmp(section, "15M"))
+		band = BAND15M;
+	else if (!strcmp(section, "12M"))	
+		band = BAND12M;
+	else if (!strcmp(section, "10M"))
+		band = BAND10M;	
 
+	if (band != -1) {
 		//get the freq out first
-		int freq = atoi(value);
-		if (freq < band_stack[band].start || band_stack[band].stop < freq)
-			return 1;
-		if (band >= 0  && !strcmp(name, "freq0"))
+		if (strstr(name,"freq")) {
+			int freq = atoi(value);
+			if (freq < band_stack[band].start || band_stack[band].stop < freq)
+				return 1;
+		}
+		if (!strcmp(name, "freq0"))
 			band_stack[band].freq[0] = atoi(value);
-		else if (band >= 0  && !strcmp(name, "freq1"))
+		else if (!strcmp(name, "freq1"))
 			band_stack[band].freq[1] = atoi(value);
-		else if (band >= 0  && !strcmp(name, "freq2"))
+		else if (!strcmp(name, "freq2"))
 			band_stack[band].freq[2] = atoi(value);
-		else if (band >= 0  && !strcmp(name, "freq3"))
+		else if (!strcmp(name, "freq3"))
 			band_stack[band].freq[3] = atoi(value);
-		else if (band >= 0 && !strcmp(name, "mode0"))
+		else if (!strcmp(name, "mode0"))
 			band_stack[band].mode[0] = atoi(value);	
-		else if (band >= 0 && !strcmp(name, "mode1"))
+		else if (!strcmp(name, "mode1"))
 			band_stack[band].mode[1] = atoi(value);	
-		else if (band >= 0 && !strcmp(name, "mode2"))
+		else if (!strcmp(name, "mode2"))
 			band_stack[band].mode[2] = atoi(value);	
-		else if (band >= 0 && !strcmp(name, "mode3"))
+		else if (!strcmp(name, "mode3"))
 			band_stack[band].mode[3] = atoi(value);	
-
+	}
     return 1;
 }
 /* rendering of the fields */
@@ -2530,7 +2562,7 @@ void update_titlebar(){
 
 	time_t now = time_sbitx();
 	struct tm *tmp = gmtime(&now);
-	sprintf(buff, "sBitx %s %s %04d/%02d/%02d %02d:%02d:%02dZ",  
+	sprintf(buff, "sBitx  %s  %s  %04d/%02d/%02d  %02d:%02d:%02dZ",  
 		get_field("#mycallsign")->value, get_field("#mygrid")->value,
 		tmp->tm_year + 1900, tmp->tm_mon + 1, tmp->tm_mday, tmp->tm_hour, tmp->tm_min, tmp->tm_sec); 
  	gtk_window_set_title( GTK_WINDOW(window), buff);
@@ -4248,15 +4280,31 @@ void change_band(char *request){
 	field_set("MODE", resp);	
 	update_field(get_field("r1:mode"));
 
+    highlight_band_field(new_band);
+
 	struct field *bandswitch = get_field_by_label(band_stack[new_band].name);
+	//printf("bandswitch %s  %s -> %d\n", bandswitch->label, bandswitch->value, band_stack[new_band].index+1);
 	sprintf(bandswitch->value, "%d", band_stack[new_band].index+1);
 	sprintf(buff, "%d", new_band*10+stack);
 	set_field("#selband", buff);
 	q_empty(&q_web);// inserted by llh 
   console_init(); // inserted by llh 
   // this fixes bug with filter settings not being applied after a band change, not sure why it's a bug - k3ng 2022-09-03
-
 	abort_tx();
+	settings_updated++;
+}
+
+void highlight_band_field(int new_band) {
+	int max_bands = sizeof(band_stack)/sizeof(struct band);
+	for( int b = 0; b < max_bands; b++) {
+		struct field *band_field = get_field_by_label(band_stack[b].name);
+		if ( b == new_band) {
+			band_field->font_index = FONT_FIELD_SELECTED;
+		} else {
+			band_field->font_index = FONT_FIELD_VALUE;
+		}
+		update_field(band_field);
+	}
 }
 
 void utc_set(char *args, int update_rtc){

--- a/sbitx_gtk.c
+++ b/sbitx_gtk.c
@@ -618,7 +618,7 @@ struct field main_controls[] = {
   { "mouse_pointer", NULL, 1000, -1000, 50, 50, "MP", 40, "LEFT", FIELD_SELECTION, FONT_FIELD_VALUE,
     "BLANK/LEFT/RIGHT/CROSSHAIR", 0,0,0,0},
   { "#selband", NULL, 1000, -1000, 50, 50, "SELBAND", 40, "", FIELD_NUMBER, FONT_FIELD_VALUE,
-    "", 0,73,1, 0},
+    "", 0,83,1, 0},
 
 	// Settings Panel
 	{"#mycallsign", NULL, 1000, -1000, 400, 149, "MYCALLSIGN", 70, "CALL", FIELD_TEXT, FONT_SMALL, 
@@ -4250,6 +4250,7 @@ void change_band(char *request){
 
 	struct field *bandswitch = get_field_by_label(band_stack[new_band].name);
 	sprintf(bandswitch->value, "%d", band_stack[new_band].index+1);
+	sprintf(buff, "%d", new_band*10+stack);
 	set_field("#selband", buff);
 	q_empty(&q_web);// inserted by llh 
   console_init(); // inserted by llh 

--- a/sdr_ui.h
+++ b/sdr_ui.h
@@ -39,7 +39,7 @@ extern int display_freq;
 #define FF_MYCALL 16
 #define FF_CALLER 17
 #define FF_GRID 18
-
+#define FONT_FIELD_SELECTED 19
 
 void enter_qso();
 void call_wipe();

--- a/web/index.html
+++ b/web/index.html
@@ -164,6 +164,12 @@
 		><button class="sbitxv3-btn" id="wipe">WIPE</button
 		><button class="sbitxv3-btn" id="logbook-open">LOG</button
 		><div class="sbitxv3-control">
+			<div class="sbitxv3-label">TUNE</div>
+			<select class="sbitxv3-selection sbitx-selection" id="TUNE">
+				<option value="OFF">OFF</option>
+				<option value="ON">ON</option>
+			</select>
+		</div><div class="sbitxv3-control">
 			<div class="sbitxv3-label">SPAN</div>
 			<select class="sbitxv3-selection sbitx-selection" id="SPAN">
 				<option value="25K">25K</option>

--- a/web/index.html
+++ b/web/index.html
@@ -75,6 +75,7 @@
 		</div><!-- funny html that breaks the line inside the button tag to 
 		prevent spaces between the elements 
 		--><button class="sbitxv3-btn" id="80M" type="submit">80M<span id="S80" class="selband"></span></button
+			><button class="sbitxv3-btn" id="60M" type="submit">60M<span id="S60" class="selband"></span></button
 			><button class="sbitxv3-btn" id="40M" type="submit">40M<span id="S40" class="selband"></span></button
 			><button class="sbitxv3-btn" id="30M" type="submit">30M<span id="S30" class="selband"></span></button
 			><button class="sbitxv3-btn" id="20M" type="submit">20M<span id="S20" class="selband"></span></button


### PR DESCRIPTION
This pull request should fix issue #102 
(I am new to "pull requests" but I hope this is usable. My llhdev branch is based on afarhandev)
Quoted from issue #102:

1) The buff argument to set_field in sbitx_gtx.c line 4252 needs to be set:
```
	sprintf(buff, "%d", new_band*10+stack);
	set_field("#selband", buff);
```

The value is two digits the first indicates the band and the last the current stack;

2) Due to the added 60M band the #selband "command" must have it max value increased.
sbitx_gtx.c line 620  (new max value 83: band select 0-8 stack 0-3)

```
  { "#selband", NULL, 1000, -1000, 50, 50, "SELBAND", 40, "", FIELD_NUMBER, FONT_FIELD_VALUE,
    "", 0,83,1, 0},
```
3) The 60M band needs to be added in  index.html line 78

```
<button class="sbitxv3-btn" id="60M" type="submit">60M<span id="S60" class="selband"></span></button>
```

4) I had to add the 60M band to the hw_settings.ini. Something like

```
[tx_band]
f_start=5250000
f_stop=5450000
scale=0.0156247
```
After this I was able to make my first ft8 contact on 60M using the web app :-)
